### PR TITLE
PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.php_cs
 /.php_cs.cache
+/.phpunit.result.cache
 /composer.lock
 /phpunit.xml
 /vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     include:
         -
             stage: Static Code Analysis
-            php: 7.2
+            php: 7.4
             env: COMPOSER_FLAGS="--no-dev --prefer-stable"
             install:
                 - travis_retry composer update -d dev-tools $DEFAULT_COMPOSER_FLAGS
@@ -36,6 +36,7 @@ jobs:
                 - ./dev-tools/vendor/bin/phpmd src,tests text phpmd.xml || travis_terminate 1
                 - ./dev-tools/vendor/bin/composer-require-checker check composer.json || travis_terminate 1
                 - ./dev-tools/vendor/bin/php-cs-fixer fix -v
+            dist: xenial
 
         - &STANDARD_TEST_JOB
             stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 git:
     depth: 1
 
@@ -18,14 +16,14 @@ before_install:
     # turn off XDebug
     - phpenv config-rm xdebug.ini || return 0
 
-    # Composer: boost installation
-    - composer global show -ND 2>&1 | grep "hirak/prestissimo" || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
+    # Composer v2
+    - composer self-update --2
 
 jobs:
     include:
         -
             stage: Static Code Analysis
-            php: 7.1
+            php: 7.2
             env: COMPOSER_FLAGS="--no-dev --prefer-stable"
             install:
                 - travis_retry composer update -d dev-tools $DEFAULT_COMPOSER_FLAGS
@@ -41,26 +39,19 @@ jobs:
 
         - &STANDARD_TEST_JOB
             stage: Test
-            php: 5.4
+            php: 5.6
             install:
                 - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
                 - composer info -D | sort
             script:
-                - vendor/bin/phpunit --verbose
-
-        -
-            <<: *STANDARD_TEST_JOB
-            php: 5.3
-            env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-            dist: precise
-
-        -
-            <<: *STANDARD_TEST_JOB
-            php: 5.5
+                - vendor/bin/simple-phpunit
+            dist: xenial
 
         -
             <<: *STANDARD_TEST_JOB
             php: 5.6
+            env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+            dist: xenial
 
         -
             <<: *STANDARD_TEST_JOB
@@ -69,8 +60,25 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             php: 7.1
+            dist: bionic
+
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 7.2
+            dist: bionic
+
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 7.3
+            dist: bionic
+
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 7.4
+            dist: bionic
 
         -
             <<: *STANDARD_TEST_JOB
             php: nightly
             env: SYMFONY_DEPRECATIONS_HELPER=weak
+            dist: bionic

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,10 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0"
+        "php": "^5.6 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.4.3",
-        "symfony/phpunit-bridge": "^3.2.2"
-    },
-    "conflict": {
-        "hhvm": "*"
+        "symfony/phpunit-bridge": "^5.1"
     },
     "config": {
         "optimize-autoloader": true,

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -1,10 +1,10 @@
 {
     "require": {
-        "php": "^7.2"
+        "php": "^7.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.15",
-        "maglnet/composer-require-checker": "^2.1",
+        "friendsofphp/php-cs-fixer": "^2.16.4",
+        "maglnet/composer-require-checker": "^2.1.1@dev",
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.6"
     },

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -1,15 +1,12 @@
 {
     "require": {
-        "php": "^7.0"
+        "php": "^7.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.4",
-        "maglnet/composer-require-checker": "^0.1.5",
-        "mi-schi/phpmd-extension": "^4.2",
+        "friendsofphp/php-cs-fixer": "^2.15",
+        "maglnet/composer-require-checker": "^2.1",
+        "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.6"
-    },
-    "conflict": {
-        "hhvm": "*"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/AccessibleObjectTest.php
+++ b/tests/AccessibleObjectTest.php
@@ -27,7 +27,10 @@ final class AccessibleObjectTest extends TestCase
 {
     protected $accessibleObject;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpProperty()
     {
         $this->accessibleObject = new AccessibleObject(new DummyClass());
     }


### PR DESCRIPTION
Support PHP `^5.6 || ^7.0 || ^8.0`, and test on all those versions. This can be merged and tagged as v1.1.0.